### PR TITLE
OCTET STRING scalar SIZE, BIT STRING bits optional, hypens in ASN.1 identifiers

### DIFF
--- a/asn1ate/parser.py
+++ b/asn1ate/parser.py
@@ -229,7 +229,7 @@ def _build_asn1_grammar():
     # todo: consider the full subtype and general constraint syntax described in 45.*
     # but for now, just implement a simple integer value range.
     value_range_constraint = (signed_number | valuereference | MIN) + Suppress('..') + (signed_number | valuereference | MAX)
-    size_constraint = Optional(Suppress('(')) + Suppress(SIZE) + Suppress('(') + value_range_constraint + Suppress(')') + Optional(Suppress(')'))
+    size_constraint = Optional(Suppress('(')) + Suppress(SIZE) + Suppress('(') + (value_range_constraint | signed_number) + Suppress(')') + Optional(Suppress(')'))
     constraint = Suppress('(') + value_range_constraint + Suppress(')')
 
     # TODO: consider exception syntax from 24.1
@@ -252,14 +252,15 @@ def _build_asn1_grammar():
     setof_type = Suppress(SET) + Optional(size_constraint) + Suppress(OF) + (type_ | named_type)
     choice_type = CHOICE + braced_list(named_type | extension_marker)
     enumerated_type = ENUMERATED + braced_list(enumeration | extension_marker)
-    bitstring_type = BIT_STRING + braced_list(named_number)
+    bitstring_type = BIT_STRING + Optional(braced_list(named_number))
     plain_integer_type = INTEGER
     restricted_integer_type = INTEGER + braced_list(named_number)
     boolean_type = BOOLEAN
     real_type = REAL
     null_type = NULL
     object_identifier_type = OBJECT_IDENTIFIER
-    octetstring_type = OCTET_STRING
+    octetstring_type = OCTET_STRING + Optional(size_constraint)
+    
     unrestricted_characterstring_type = CHARACTER_STRING
     restricted_characterstring_type = BMPString | GeneralString | \
                                       GraphicString | IA5String | \

--- a/asn1ate/sema.py
+++ b/asn1ate/sema.py
@@ -165,10 +165,16 @@ class Module(object):
     __repr__ = __str__
 
 
+def sanitise_name(input_name):
+    """ Map ASN.1 name to a valid Python class name """
+    return input_name.replace('-', 'Z')
+
+
 class TypeAssignment(object):
     def __init__(self, elements):
         assert(len(elements) == 3)
         type_name, _, type_decl = elements
+        type_name = sanitise_name(type_name)     
         self.type_name = type_name
         self.type_decl = _create_sema_node(type_decl)
 
@@ -194,6 +200,7 @@ class ValueAssignment(object):
         value_name, type_name, _, value = elements
         self.value_name = ValueReference(value_name.elements) # First token is always a valuereference
         self.type_decl = _create_sema_node(type_name)
+
 
         if isinstance(value, parser.AnnotatedToken):
             self.value = _create_sema_node(value) 
@@ -365,9 +372,12 @@ class TaggedType(object):
 class SimpleType(object):
     def __init__(self, elements):
         self.constraint = None
+        self.size_constraint = None
         self.type_name = elements[0]
         if len(elements) > 1 and elements[1].ty == 'Constraint':
             self.constraint = Constraint(elements[1].elements)
+        if len(elements) > 1 and elements[1].ty == 'SizeConstraint':
+            self.size_constraint = SizeConstraint(elements[1].elements)
 
     def reference_name(self):
         return self.type_name
@@ -390,7 +400,7 @@ class SimpleType(object):
 
 class UserDefinedType(object):
     def __init__(self, elements):
-        self.type_name = elements[0]
+        self.type_name = sanitise_name(elements[0])     
 
     def reference_name(self):
         return self.type_name
@@ -406,7 +416,11 @@ class UserDefinedType(object):
 
 class Constraint(object):
     def __init__(self, elements):
-        min_value, max_value = elements
+        if len(elements) > 1:
+            min_value, max_value = elements
+        elif len(elements) == 1:
+            min_value = elements[0]
+            max_value = min_value
 
         self.min_value = _maybe_create_sema_node(min_value)
         self.max_value = _maybe_create_sema_node(max_value)
@@ -534,26 +548,8 @@ class ValueListType(object):
     __repr__ = __str__
 
 
-class BitStringType(object):
-    def __init__(self, elements):
-        self.type_name = elements[0]
-        if len(elements) > 1:
-            self.named_bits = [_create_sema_node(token) for token in elements[1]]
-        else:
-            self.named_bits = None
-
-    def references(self):
-        # TODO: Value references
-        return []
-
-    def __str__(self):
-        if self.named_bits:
-            named_bit_list = ', '.join(map(str, self.named_bits))
-            return '%s { %s }' % (self.type_name, named_bit_list)
-        else:
-            return '%s' % self.type_name
-
-    __repr__ = __str__
+class BitStringType(ValueListType):
+    pass
 
 
 class NamedValue(object):

--- a/testdata/builtin_types.asn
+++ b/testdata/builtin_types.asn
@@ -17,6 +17,8 @@ BEGIN
     b(2)
   }
 
+  UnenumeratedBitString ::= BIT STRING
+
   Enumerated ::= ENUMERATED {
     a(1),
     b(2),

--- a/testdata/invalid_identifiers.asn
+++ b/testdata/invalid_identifiers.asn
@@ -1,0 +1,8 @@
+-- Examples of invalid identifiers that should be safely sanitised to conform with Python class naming conventions.
+TEST DEFINITIONS ::=
+BEGIN
+
+  -- '-' is valid in ASN but not Python identifiers
+  Invalid-name ::= OCTET STRING
+
+END

--- a/testdata/string_types.asn
+++ b/testdata/string_types.asn
@@ -3,6 +3,8 @@ BEGIN
   -- Mostly a simple way to test that type
   -- translation in codegen happens correctly.
   OctetStr ::= OCTET STRING
+  OctetRangeSizeLimitStr ::= OCTET STRING SIZE(5..10)
+  OctetFixedSizeLimitStr ::= OCTET STRING SIZE(5)
   GeneralStr ::= GeneralString
   Utf8Str ::= UTF8String
   NumStr ::= NumericString


### PR DESCRIPTION
Added support for OCTET STRING SIZE with single scalar value as opposed to a range.

Bit string now optionally has a succeeding list of named bits.
Added possibility to use identifiers in ASN.1 with hypens by transposing each occurrence of this character to a Z.
