### PR TITLE
Allow multi-module processing.

### DIFF
--- a/testdata/multi_module.asn
+++ b/testdata/multi_module.asn
@@ -6,6 +6,8 @@ OneSequence ::= SEQUENCE {
     second BOOLEAN
 }
 
+value INTEGER ::= 123
+
 END
 
 
@@ -16,5 +18,12 @@ AnotherSequence ::= SEQUENCE {
     first INTEGER,
     second BOOLEAN
 }
+
+YetAnotherSequence ::= SEQUENCE {
+    first [0] Module1.OneSequence,
+    second [1] AnotherSequence
+}
+
+anothervalue INTEGER ::= Module1.value
 
 END


### PR DESCRIPTION
During semantic parsing, definitions with reference to other modules
have a member variable set in the ReferencedValue class.
In order to allow base types to be determined by searching the tree
of other modules, the Module class now has a member variable
'referenced_modules' which it searches through. Modules in this list
are also added to the output as import statements.

The main function in pyasn1gen.py has been modified to take a command
line switch to output multiple modules to separate files rather than
stdout.