### PR TITLE
Parse automatic tags.

### DIFF
--- a/asn1ate/sema.py
+++ b/asn1ate/sema.py
@@ -310,9 +310,12 @@ class Module(SemaNode):
         if self.tag_default is None:
             # Explicit is default if nothing
             return TagImplicity.EXPLICIT
-        elif self.tag_default == TagImplicity.AUTOMATIC:
-            # TODO: Expand according to rules for automatic tagging.
-            return TagImplicity.IMPLICIT
+        elif self.tag_default == TagImplicity.AUTOMATIC or self.tag_default == TagImplicity.IMPLICIT:
+            # CHOICE tags must always be EXPLICIT
+            if type(self.resolve_type_decl(tagged_type_decl)) is ChoiceType:
+                return TagImplicity.EXPLICIT
+            else:
+                return TagImplicity.IMPLICIT
 
         return self.tag_default
 

--- a/testdata/module_tag_default.asn
+++ b/testdata/module_tag_default.asn
@@ -11,6 +11,7 @@ Sequence ::= SEQUENCE
 
 END
 
+-- IMPLICIT TAGS should result in EXPLICIT for CHOICE.
 ImplicitModule DEFINITIONS IMPLICIT TAGS ::=
 BEGIN
 
@@ -19,22 +20,72 @@ Sequence ::= SEQUENCE
     field1 [0] INTEGER,
     field2 [1] BOOLEAN,
     field3 [2] EXPLICIT INTEGER,
-    field4 [3] IMPLICIT BOOLEAN
+    field4 [3] IMPLICIT BOOLEAN,
+    field5 [4] CHOICE { a INTEGER,
+                    b BOOLEAN
+                  }
 }
 
 END
 
-
--- AUTOMATIC TAGS is considered the same as IMPLICIT for now.
+-- AUTOMATIC TAGS should result in implicit tags being added in order.
 AutomaticModule DEFINITIONS AUTOMATIC TAGS ::=
 BEGIN
 
 Sequence ::= SEQUENCE
 {
-    field1 [0] INTEGER,
-    field2 [1] BOOLEAN,
-    field3 [2] EXPLICIT INTEGER,
-    field4 [3] IMPLICIT BOOLEAN
+    field1 INTEGER,
+    field2 BOOLEAN,
+    field3 INTEGER,
+    field4 BOOLEAN
 }
 
 END
+
+-- AUTOMATIC TAGS should not be applied if a tag exists.
+AutomaticModule DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+Sequence ::= SEQUENCE
+{
+    field1 INTEGER,
+    field2 BOOLEAN,
+    field3 [2] INTEGER,
+    field4 BOOLEAN
+}
+
+END
+
+-- AUTOMATIC TAGS should nest. CHOICE is tagged EXPLICIT.
+-- Defined types are still EXPLICIT if they are a CHOICE.
+AutomaticModule DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+Sequence ::= SEQUENCE
+{
+    field1 INTEGER,
+    field2 CHOICE { a INTEGER,
+                    b BOOLEAN
+                  }, 
+    field3 SEQUENCE { x INTEGER,
+                      y BOOLEAN
+                    },
+    field4 SET { p INTEGER,
+                 q BOOLEAN
+               },
+    field5 BOOLEAN
+}
+
+Choice ::= CHOICE
+{
+    field1 INTEGER,
+    field2 BOOLEAN
+}
+
+Sequence2 ::= SEQUENCE {
+    field1 Choice,
+    field2 BOOLEAN
+}
+
+END
+


### PR DESCRIPTION
During the parse phase when the grammar is generated, if the
AUTOMATIC TAGS keyword is declared, a callback is added to parse
of constructed types. This callback adds sequential tags to the
elements of the constructed type (unless a tag exists, as per the
spec). The callback is not added when the module tag default is
IMPLICIT or EXPLICIT.

During creation of the semantic model, if the default tag type is
AUTOMATIC, the tagged element is tagged IMPLICIT unless it is a
CHOICE type or resolves to one.

Minor bugfix: if default tag mode is IMPLICIT, CHOICEs must still
be tagged EXPLICIT.

Resolves #20