### PR TITLE
Sort the processed items to make the output repeatable

### DIFF
--- a/asn1ate/sema.py
+++ b/asn1ate/sema.py
@@ -163,7 +163,7 @@ def dependency_sort(assignments):
             component = tuple(connected_component)
             result.append(component)
 
-    for node in graph:
+    for node in sorted(graph):
         if node not in lowlinks:
             strongconnect(node)
 

--- a/asn1ate/sema.py
+++ b/asn1ate/sema.py
@@ -163,7 +163,7 @@ def dependency_sort(assignments):
             component = tuple(connected_component)
             result.append(component)
 
-    for node in sorted(graph.keys()):
+    for node in sorted(graph.keys(), key=lambda a: a.reference_name()):
         if node not in lowlinks:
             strongconnect(node)
 

--- a/asn1ate/sema.py
+++ b/asn1ate/sema.py
@@ -163,7 +163,7 @@ def dependency_sort(assignments):
             component = tuple(connected_component)
             result.append(component)
 
-    for node in sorted(graph):
+    for node in sorted(graph.keys()):
         if node not in lowlinks:
             strongconnect(node)
 


### PR DESCRIPTION
for f in testdata/*.asn ; do comm -3 --nocheck-order <(python asn1ate/pyasn1gen.py $f | grep -v '# Auto-generated' ) <(python asn1ate/pyasn1gen.py $f | grep -v '# Auto-generated') ; done | wc -l

From master, output is 212 lines of difference.

From this branch, output is 0 lines of difference.

Hash ordering makes the output not repeatable so it's difficult to tell if running it on the same input is giving the same output.  I don't know enough about directed graphs to know if this breaks, but I do know that the existing code is not depending on any special ordering of the keys in that hash, so sorting them shouldn't matter.