### PR TITLE
Additional backend for asn1ate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+# This is asn2quickder, an ASN.1 compiler with Quick DER backend
+#
+# Quick DER is a small and efficient library for DER parsing, possible
+# entirely without memory allocation in the routines.  This makes it
+# perfect for many embedded uses, and the occasional quick actions on ASN.1
+# encoded in DER, such as plucking fields out of a certificate or ticket.
+#
+# This basically is a Python script that invokes a few library routines.
+# These install into $(DESTDIR)$(PREFIX)/lib/asn2quickder/asn1ate
+# where the reason for the asn2quickder prefix is to avoid naming conflicts
+# with any "real" asn1ate intallation; asn2quickder is a branch off asn1ate.
+#
+# References:
+# https://github.com/vanrein/asn2quickder
+# https://github.com/kimgr/asn1ate
+# https://github.com/vanrein/quick-der
+#
+# From: Rick van Rein <rick@openfortress.nl>
+
+
+DESTDIR ?=
+PREFIX ?= /usr/local
+
+SUBDIR=asn1ate
+
+BINS=asn2quickder
+LIBS=__init__ parser sema support/pygen
+
+all: $(foreach lib,$(LIBS),$(SUBDIR)/$(lib).pyc)
+
+%.pyc: %.py
+	PYTHONPATH=$(SUBDIR)/.. python -c 'import asn1ate.$(basename $(subst /,.,$(subst $(SUBDIR)/,,$<)))'
+
+%.pyo: %.pyc
+	PYTHONPATH=$(SUBDIR)/.. python -O $<
+
+clean:
+	rm -f $(foreach lib,$(LIBS),$(SUBDIR)/$(lib).pyc)
+	rm -f $(foreach lib,$(LIBS),$(SUBDIR)/$(lib).pyo)
+
+install: all
+	mkdir -p '$(DESTDIR)$(PREFIX)/lib/asn2quickder/asn1ate/support'
+	$(foreach file,$(LIBS),install $(SUBDIR)/$(file).py  '$(DESTDIR)$(PREFIX)/lib/asn2quickder/asn1ate/$(file).py'  &&) echo 'Python library files installed'
+	$(foreach file,$(LIBS),install $(SUBDIR)/$(file).pyc '$(DESTDIR)$(PREFIX)/lib/asn2quickder/asn1ate/$(file).pyc' &&) echo 'Python optimised library files installed'
+	$(foreach file,$(BINS),install $(SUBDIR)/$(file).py  '$(DESTDIR)$(PREFIX)/lib/asn2quickder/asn1ate/$(file).py'  &&) echo 'Python binary files installed'
+	( echo '#!/bin/sh' ; echo 'PYTHONPATH='"'"'$(PREFIX)/lib/asn2quickder'"'"' python '"'"'$(PREFIX)/lib/asn2quickder/asn1ate/asn2quickder.py'"'"' "$$@"' ) > '$(DESTDIR)$(PREFIX)/bin/asn2quickder'
+	chmod ugo+x '$(DESTDIR)$(PREFIX)/bin/asn2quickder'
+
+uninstall:
+	rm -f '$(DESTDIR)$(PREFIX)/bin/asn2quickder'
+	rm -rf '$(DESTDIR)$(PREFIX)/lib/asn2quickder'
+
+

--- a/README.txt
+++ b/README.txt
@@ -6,7 +6,8 @@ Introduction
 
 ``asn1ate`` is a Python library for translating ASN.1 into other forms.
 It is intended for code generation from formal ASN.1 definitions, and a
-code generator for ``pyasn1`` is included.
+code generator for ``pyasn1`` is included.  Additional code for the
+``Quick DER`` format was added later.
 
 ``asn1ate`` is released under a 3-clause BSD license. For details, see
 LICENSE.txt.
@@ -29,8 +30,8 @@ This is very much an alpha-quality prototype. Things that need doing:
   constructs, etc.
 
 
-Usage
------
+Usage with pyasn1
+-----------------
 
 The immediate use of ``asn1ate`` is to generate ``pyasn1`` definitions from
 ASN.1 definitions. The command to do this is::
@@ -38,6 +39,25 @@ ASN.1 definitions. The command to do this is::
   $ python .../asn1ate/pyasn1gen.py source.asn1
 
 It will print the ``pyasn1`` equivalent of ``source.asn1`` to stdout.
+
+
+Usage with Quick DER
+--------------------
+
+Quick DER is a library found on https://github.com/vanrein/quick-der
+A separate generator exists in ``asn1ate`` to create the parser bytecode
+and overlay structures for this format.  The command to do this is::
+
+  $ python .../asn1ate/asn2quickder.py source.asn1
+
+It will store an include file suitable for use with ``Quick DER`` in ``source.h``,
+which is the source file name with its extension changed to ``.h``.
+
+This tool can be used for your private ASN.1 projects, but one purpose of
+Quick DER is also to have a developer's toolkit with precompiled header
+files that can simply be included as
+
+  #include <quick-der/rfc5280.h>
 
 
 Dependencies
@@ -67,6 +87,8 @@ driver, a parser, a semantic model and a convention for code generators.
 * ``pyasn1gen.py`` -- a code generator to transform a semantic model into
   ``pyasn1`` syntax. This can be used as a script in which case it will dump
   output to stdout.
+* ``asn2quickder.py`` -- a code generator to transform a semantic model into
+  ``Quick DER`` include file syntax.  This can be used as a command.
 
 The ASN.1 parser is very ad-hoc, I've experimented with the grammar until I
 found something that accepted our proprietary ASN.1 definition. It's based on

--- a/README.txt
+++ b/README.txt
@@ -5,9 +5,8 @@ Introduction
 ------------
 
 ``asn1ate`` is a Python library for translating ASN.1 into other forms.
-It is intended for code generation from formal ASN.1 definitions, and a
-code generator for ``pyasn1`` is included.  Additional code for the
-``Quick DER`` format was added later.
+It is intended for code generation from formal ASN.1 definitions, and
+code generators for ``pyasn1`` as well as ``Quick DER`` are included.
 
 ``asn1ate`` is released under a 3-clause BSD license. For details, see
 LICENSE.txt.
@@ -53,11 +52,16 @@ and overlay structures for this format.  The command to do this is::
 It will store an include file suitable for use with ``Quick DER`` in ``source.h``,
 which is the source file name with its extension changed to ``.h``.
 
-This tool can be used for your private ASN.1 projects, but one purpose of
-Quick DER is also to have a developer's toolkit with precompiled header
-files that can simply be included as
+This tool can be used for your personal ASN.1 projects, but one purpose of
+Quick DER is to supply developers with a toolkit that installs header files
+for commonly used DER formats, that can be simply included as
 
   #include <quick-der/rfc5280.h>
+
+When building Quick DER, such header files are constructed for the ASN.1
+files included in the Quick DER package, and they are installed alongside
+the rest of Quick DER.  That use of the `asn2quickder` backend could be
+considered a "build-time" dependency of Quick DER.
 
 
 Dependencies

--- a/asn1ate/asn2quickder.py
+++ b/asn1ate/asn2quickder.py
@@ -10,7 +10,20 @@
 # a very big thank you to Schneider Electric Buildings AB for helping to
 # make this program possible!
 #
-# Copyright 2016 InternetWide.org and the ARPA2.net project.
+# Copyright (c) 2016 OpenFortress B.V. and InternetWide.org
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Schneider Electric Buildings AB nor the
+#       names of contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
 
 
 import sys
@@ -20,7 +33,7 @@ from asn1ate import parser
 from asn1ate.sema import * 
 
 
-def toCsym (name):
+def tosym(name):
     """Replace unsupported characters in ASN.1 symbol names"""
     return str(name).replace(' ', '').replace('-', '_')
 
@@ -40,10 +53,10 @@ class QuickDERgen():
        this is a walking path for the der_pack() and der_unpack() instructions.
        In addition, there will be a struct for each of the symbols:
 
-       struct unit_SyntaxDeclSym_ovly {
+       struct unit_SyntaxDeclSym_overlay {
            dercursor field1;
            dercursor field2;
-           struct unit_EmbeddedSym_ovly field3;
+           struct unit_EmbeddedSym_overlay field3;
            dercursor field4;
        };
 
@@ -57,24 +70,23 @@ class QuickDERgen():
         self.refmods = refmods
         if outfn [-2:] == '.h':
             raise Exception('File cannot overwrite itself -- use another extension than .h for input files')
-        self.unit = toCsym(outfn.rsplit('.', 1) [0])
+        self.unit = tosym(outfn.rsplit('.', 1) [0])
         self.outfile = open(self.unit + '.h', 'w')
-        self.wout = self.outfile.write
         # Setup function maps
-        self.ovly_funmap = {
-            DefinedType: self.ovlyDefinedType,
+        self.overlay_funmap = {
+            DefinedType: self.overlayDefinedType,
             ValueAssignment: self.ignore_node,
-            TypeAssignment: self.ovlyTypeAssignment,
-            TaggedType: self.ovlyTaggedType,
-            SimpleType: self.ovlySimpleType,
-            BitStringType: self.ovlySimpleType,
-            ValueListType: self.ovlySimpleType,
-            SequenceType: self.ovlyConstructedType,
-            SetType: self.ovlyConstructedType,
-            ChoiceType: self.ovlyConstructedType,
-            SequenceOfType: self.ovlySimpleType,    # var sized
-            SetOfType: self.ovlySimpleType,         # var sized
-            ComponentType: self.ovlySimpleType,  #TODO#
+            TypeAssignment: self.overlayTypeAssignment,
+            TaggedType: self.overlayTaggedType,
+            SimpleType: self.overlaySimpleType,
+            BitStringType: self.overlaySimpleType,
+            ValueListType: self.overlaySimpleType,
+            SequenceType: self.overlayConstructedType,
+            SetType: self.overlayConstructedType,
+            ChoiceType: self.overlayConstructedType,
+            SequenceOfType: self.overlaySimpleType,    # var sized
+            SetOfType: self.overlaySimpleType,         # var sized
+            ComponentType: self.overlaySimpleType,  #TODO#
         }
         self.pack_funmap = {
             DefinedType: self.packDefinedType,
@@ -83,7 +95,7 @@ class QuickDERgen():
             TaggedType: self.packTaggedType,
             SimpleType: self.packSimpleType,
             BitStringType: self.packSimpleType,
-            ValueListType: self.ovlySimpleType,
+            ValueListType: self.overlaySimpleType,
             SequenceType: self.packSequenceType,
             SetType: self.packSetType,
             ChoiceType: self.packChoiceType,
@@ -92,193 +104,220 @@ class QuickDERgen():
             ComponentType: self.packSimpleType,  #TODO#
         }
 
+    def write(self, txt):
+        self.outfile.write(txt)
+
+    def writeln(self, txt=''):
+        self.outfile.write(txt + '\n')
+
     def newcomma(self, comma, firstcomma=''):
         self.comma0 = firstcomma
         self.comma1 = comma
 
     def comma(self):
-        self.wout(self.comma0)
+        self.write(self.comma0)
         self.comma0 = self.comma1
 
     def close(self):
         self.outfile.close()
 
     def generate_head(self):
-        self.wout('/*\n * asn2quickder output for ' + self.semamod.name + ' -- automatically generated\n *\n * For information on Quick `n\' Easy DER, see https://github.com/vanrein/quick-der\n *\n * For information on the code generator, see https://github.com/vanrein/asn2quickder\n *\n */\n\n\n#include <quick-der/api.h>\n\n\n')
+        self.writeln('/*')
+        self.writeln(' * asn2quickder output for ' + self.semamod.name + ' -- automatically generated')
+        self.writeln(' *')
+        self.writeln(' * For information on Quick `n\' Easy DER, see https://github.com/vanrein/quick-der')
+        self.writeln(' *')
+        self.writeln(' * For information on the code generator, see https://github.com/vanrein/asn2quickder')
+        self.writeln(' *')
+        self.writeln(' */')
+        self.writeln('')
+        self.writeln('')
+        self.writeln('#include <quick-der/api.h>')
+        self.writeln('')
+        self.writeln('')
         closer = ''
         for rm in self.semamod.imports.module2symbols.keys():
-            rmfn = toCsym(rm.rsplit('.', 1) [0]).lower()
-            self.wout('#include <quick-der/' + rmfn + '.h>\n')
+            rmfn = tosym(rm.rsplit('.', 1) [0]).lower()
+            self.writeln('#include <quick-der/' + rmfn + '.h>')
             closer = '\n\n'
-        self.wout(closer)
+        self.write(closer)
         closer = ''
         for rm in self.semamod.imports.module2symbols.keys():
-            rmfn = toCsym(rm.rsplit('.', 1) [0]).lower()
+            rmfn = tosym(rm.rsplit('.', 1) [0]).lower()
             for sym in self.semamod.imports.module2symbols [rm]:
-                self.wout('typedef DER_OVLY_' + toCsym(rmfn) + '_' + toCsym(sym) + ' DER_OVLY_' + toCsym(self.unit) + '_' + toCsym(sym) + ';\n')
+                self.writeln('typedef DER_OVLY_' + tosym(rmfn) + '_' + tosym(sym) + ' DER_OVLY_' + tosym(self.unit) + '_' + tosym(sym) + ';')
                 closer = '\n\n'
-        self.wout(closer)
+        self.write(closer)
         closer = ''
         for rm in self.semamod.imports.module2symbols.keys():
-            rmfn = toCsym(rm.rsplit('.', 1) [0]).lower()
+            rmfn = tosym(rm.rsplit('.', 1) [0]).lower()
             for sym in self.semamod.imports.module2symbols [rm]:
-                self.wout('#define DER_PACK_' + toCsym(self.unit) + '_' + toCsym(sym) + ' DER_PACK_' + toCsym(rmfn) + '_' + toCsym(sym) + '\n')
+                self.writeln('#define DER_PACK_' + tosym(self.unit) + '_' + tosym(sym) + ' DER_PACK_' + tosym(rmfn) + '_' + tosym(sym) + '')
                 closer = '\n\n'
-        self.wout(closer)
+        self.write(closer)
 
     def generate_tail(self):
-        self.wout('\n\n/* asn2quickder output for ' + self.semamod.name + ' ends here */\n')
+        self.writeln()
+        self.writeln()
+        self.writeln('/* asn2quickder output for ' + self.semamod.name + ' ends here */')
 
-    def generate_ovly(self):
-        self.wout('\n\n/* Overlay structures with ASN.1 derived nesting and labelling */\n\n')
+    def generate_overlay(self):
+        self.writeln()
+        self.writeln()
+        self.writeln('/* Overlay structures with ASN.1 derived nesting and labelling */')
+        self.writeln()
         for assigncompos in dependency_sort(self.semamod.assignments):
             for assign in assigncompos:
-                self.generate_ovly_node(assign)
+                self.generate_overlay_node(assign)
 
     def generate_pack(self):
-        self.wout('\n\n/* Parser definitions in terms of ASN.1 derived bytecode instructions */\n\n')
+        self.writeln()
+        self.writeln()
+        self.writeln('/* Parser definitions in terms of ASN.1 derived bytecode instructions */')
+        self.writeln()
         for assigncompos in dependency_sort(self.semamod.assignments):
             for assign in assigncompos:
                 tnm = type(assign)
                 if tnm in self.pack_funmap:
                     self.pack_funmap [tnm](assign)
                 else:
-                    print 'No pack generator for ' + str(tnm)
+                    raise Exception('No pack generator for ' + str(tnm))
 
-    def generate_ovly_node(self, node):
+    def generate_overlay_node(self, node):
         tnm = type(node)
-        if tnm in self.ovly_funmap:
-            self.ovly_funmap [tnm](node)
+        if tnm in self.overlay_funmap:
+            self.overlay_funmap [tnm](node)
         else:
-            print('No overlay generator for ' + str(tnm))
-            raise Exception('RAISED WHERE?')
+            raise Exception('No overlay generator for ' + str(tnm))
 
     def generate_pack_node(self, node):
         tnm = type(node)
         if tnm in self.pack_funmap:
             self.pack_funmap [tnm](node)
         else:
-            print('No pack generator for ' + str(tnm))
+            raise Exception('No pack generator for ' + str(tnm))
 
     def ignore_node(self, node):
         pass
 
-    def ovlyTypeAssignment(self, node):
-        self.wout('typedef ')
-        self.generate_ovly_node(node.type_decl)
-        self.wout(' DER_OVLY_' + self.unit + '_' + toCsym(node.type_name) + ';\n\n')
+    def overlayTypeAssignment(self, node):
+        self.write('typedef ')
+        self.generate_overlay_node(node.type_decl)
+        self.writeln(' DER_OVLY_' + self.unit + '_' + tosym(node.type_name) + ';')
+        self.writeln()
 
     def packTypeAssignment(self, node):
-        self.wout('#define DER_PACK_' + self.unit + '_' + toCsym(node.type_name))
+        self.write('#define DER_PACK_' + self.unit + '_' + tosym(node.type_name))
         self.newcomma(', \\\n\t', ' \\\n\t')
         self.generate_pack_node(node.type_decl)
-        self.wout('\n\n')
+        self.writeln()
+        self.writeln()
 
-    def ovlyDefinedType(self, node):
+    def overlayDefinedType(self, node):
         mod = node.module_name or self.unit
-        self.wout('DER_OVLY_' + toCsym(mod) + '_' + toCsym(node.type_name))
+        self.write('DER_OVLY_' + tosym(mod) + '_' + tosym(node.type_name))
 
     def packDefinedType(self, node):
         mod = node.module_name or self.unit
         self.comma()
-        self.wout('DER_PACK_' + toCsym(mod) + '_' + toCsym(node.type_name))
+        self.write('DER_PACK_' + tosym(mod) + '_' + tosym(node.type_name))
 
-    def ovlySimpleType(self, node):
-        self.wout('dercursor')
+    def overlaySimpleType(self, node):
+        self.write('dercursor')
 
     def packSimpleType(self, node):
         self.comma()
-        self.wout('DER_PACK_STORE | DER_TAG_' + node.type_name.replace(' ', '').upper())
+        self.write('DER_PACK_STORE | DER_TAG_' + node.type_name.replace(' ', '').upper())
 
-    def ovlyTaggedType(self, node):
+    def overlayTaggedType(self, node):
         # tag = str(node) 
         # tag = tag [:tag.find(']')] + ']'
-        # self.wout('/* ' + tag + ' */ ')
+        # self.write('/* ' + tag + ' */ ')
         # if node.implicity == TagImplicity.IMPLICIT:
         #     tag = tag + ' IMPLICIT'
         # elif node.implicity == TagImplicity.IMPLICIT:
         #     tag = tag + ' EXPLICIT'
-        self.generate_ovly_node(node.type_decl)
+        self.generate_overlay_node(node.type_decl)
 
     def packTaggedType(self, node):
         #TODO# Need to push down node.implicity == TagImplicity.IMPLICIT
         #TODO# Need to process tag class
         self.comma()
-        self.wout('DER_PACK_ENTER | DER_TAG_' +(node.class_name or 'CONTEXT') + '(' + node.class_number + ')')
+        self.write('DER_PACK_ENTER | DER_TAG_' +(node.class_name or 'CONTEXT') + '(' + node.class_number + ')')
         self.generate_pack_node(node.type_decl)
         self.comma()
-        self.wout('DER_PACK_LEAVE')
+        self.write('DER_PACK_LEAVE')
 
     # Sequence, Set, Choice
-    def ovlyConstructedType(self, node):
-        self.wout('struct {\n');
+    def overlayConstructedType(self, node):
+        self.writeln('struct {');
         for comp in node.components:
             if isinstance(comp, ExtensionMarker):
-                self.wout('\t/* ...extensions... */\n')
+                self.writeln('\t/* ...extensions... */')
                 continue
             if isinstance(comp, ComponentType) and comp.components_of_type is not None:
-                self.wout('\t/* TODO: COMPONENTS OF TYPE ' + str(comp.components_of_type) + ' */\n')
+                self.writeln('\t/* TODO: COMPONENTS OF TYPE ' + str(comp.components_of_type) + ' */')
                 continue
-            self.wout('\t')
-            self.generate_ovly_node(comp.type_decl)
-            self.wout(' ' + toCsym(comp.identifier) + '; // ' + str(comp.type_decl) + '\n')
-        self.wout('}')
+            self.write('\t')
+            self.generate_overlay_node(comp.type_decl)
+            self.writeln(' ' + tosym(comp.identifier) + '; // ' + str(comp.type_decl))
+        self.write('}')
 
     def packSequenceType(self, node):
         self.comma()
-        self.wout('DER_PACK_ENTER | DER_TAG_SEQUENCE')
+        self.write('DER_PACK_ENTER | DER_TAG_SEQUENCE')
         for comp in node.components:
             if isinstance(comp, ExtensionMarker):
                 self.comma()
-                self.wout('/* ...ASN.1 extensions... */')
+                self.write('/* ...ASN.1 extensions... */')
                 continue
             if comp.optional:
                 self.comma()
-                self.wout('DER_PACK_OPTIONAL')
+                self.write('DER_PACK_OPTIONAL')
             if comp.type_decl is not None:
                 # TODO: None would be due to components_of_type
                 self.generate_pack_node(comp.type_decl)
         self.comma()
-        self.wout('DER_PACK_LEAVE')
+        self.write('DER_PACK_LEAVE')
 
     def packSetType(self, node):
         self.comma()
-        self.wout('DER_PACK_ENTER | DER_TAG_SET')
+        self.write('DER_PACK_ENTER | DER_TAG_SET')
         for comp in node.components:
             if isinstance(comp, ExtensionMarker):
                 self.comma()
-                self.wout('/* ...extensions... */')
+                self.write('/* ...extensions... */')
                 continue
             if comp.optional:
                 self.comma()
-                self.wout('DER_PACK_OPTIONAL')
+                self.write('DER_PACK_OPTIONAL')
             if comp.type_decl is not None:
                 # TODO: None would be due to components_of_type
                 self.generate_pack_node(comp.type_decl)
         self.comma()
-        self.wout('DER_PACK_LEAVE')
+        self.write('DER_PACK_LEAVE')
 
     def packChoiceType(self, node):
         self.comma()
-        self.wout('DER_PACK_CHOICE_BEGIN')
+        self.write('DER_PACK_CHOICE_BEGIN')
         for comp in node.components:
             if isinstance(comp, ExtensionMarker):
                 self.comma()
-                self.wout('/* ...extensions... */')
+                self.write('/* ...extensions... */')
                 continue
             if comp.type_decl is not None:
                 # TODO: None would be due to components_of_type
                 self.generate_pack_node(comp.type_decl)
         self.comma()
-        self.wout('DER_PACK_CHOICE_END')
+        self.write('DER_PACK_CHOICE_END')
 
     def packSequenceOfType(self, node):
         self.comma()
-        self.wout('DER_PACK_STORE | DER_TAG_SEQUENCE')
+        self.write('DER_PACK_STORE | DER_TAG_SEQUENCE')
 
     def packSetOfType(self, node):
         self.comma()
-        self.wout('DER_PACK_STORE | DER_TAG_SEQUENCE')
+        self.write('DER_PACK_STORE | DER_TAG_SEQUENCE')
 
 
 """The main program asn2quickder is called with one or more .asn1 files,
@@ -295,7 +334,7 @@ mods = []
 for file in sys.argv [1:]:
     print('Parsing', file)
     with open(file, 'r') as asn1fh:
-	asn1txt  = asn1fh.read ()
+        asn1txt  = asn1fh.read()
         asn1tree = parser.parse_asn1(asn1txt)
     print('Building semantic model for', file)
     asn1sem = build_semantic_model(asn1tree)
@@ -305,7 +344,7 @@ for file in sys.argv [1:]:
 cogen = QuickDERgen(mods [-1], os.path.basename(sys.argv [1]), mods [1:])
 
 cogen.generate_head()
-cogen.generate_ovly()
+cogen.generate_overlay()
 cogen.generate_pack()
 cogen.generate_tail()
 

--- a/asn1ate/asn2quickder.py
+++ b/asn1ate/asn2quickder.py
@@ -295,8 +295,8 @@ mods = []
 for file in sys.argv [1:]:
     print('Parsing', file)
     with open(file, 'r') as asn1fh:
-        asn1tree = parser.parse_asn1(asn1fh.read())
-    asn1tree = parser.parse_asn1(asn1txt)
+	asn1txt  = asn1fh.read ()
+        asn1tree = parser.parse_asn1(asn1txt)
     print('Building semantic model for', file)
     asn1sem = build_semantic_model(asn1tree)
     mods.insert(0, asn1sem [0])

--- a/asn1ate/asn2quickder.py
+++ b/asn1ate/asn2quickder.py
@@ -170,7 +170,7 @@ class QuickDERgen():
 
     def packTypeAssignment(self, node):
         self.wout('#define DER_PACK_' + self.unit + '_' + toCsym(node.type_name))
-        self.newcomma(', \\\\\n\t', ' \\\\\n\t')
+        self.newcomma(', \\\n\t', ' \\\n\t')
         self.generate_pack_node(node.type_decl)
         self.wout('\n\n')
 
@@ -204,7 +204,7 @@ class QuickDERgen():
         #TODO# Need to push down node.implicity == TagImplicity.IMPLICIT
         #TODO# Need to process tag class
         self.comma()
-        self.wout('DER_PACK_ENTER | DER_' +(node.class_name or 'CONTEXT') + '_TAG(' + node.class_number + ')')
+        self.wout('DER_PACK_ENTER | DER_TAG_' +(node.class_name or 'CONTEXT') + '(' + node.class_number + ')')
         self.generate_pack_node(node.type_decl)
         self.comma()
         self.wout('DER_PACK_LEAVE')

--- a/asn1ate/asn2quickder.py
+++ b/asn1ate/asn2quickder.py
@@ -112,10 +112,24 @@ class QuickDERgen ():
 		# 	ik.wout (' *   (no other modules)\n')
 		# ik.wout (' */\n\n')
 		closer = ''
-		for rm in ik.refmods:
-			rmfn = toCsym (rm.rsplit ('.', 1) [0])
-			ik.wout ('#include <quick-der/' + rmfn + '\n')
+		for rm in ik.semamod.imports.module2symbols.keys ():
+			rmfn = toCsym (rm.rsplit ('.', 1) [0]).lower ()
+			ik.wout ('#include <quick-der/' + rmfn + '.h>\n')
 			closer = '\n\n'
+		ik.wout (closer)
+		closer = ''
+		for rm in ik.semamod.imports.module2symbols.keys ():
+			rmfn = toCsym (rm.rsplit ('.', 1) [0]).lower ()
+			for sym in ik.semamod.imports.module2symbols [rm]:
+				ik.wout ('typedef DER_OVLY_' + toCsym (rmfn) + '_' + toCsym (sym) + ' DER_OVLY_' + toCsym (ik.unit) + '_' + toCsym (sym) + ';\n')
+				closer = '\n\n'
+		ik.wout (closer)
+		closer = ''
+		for rm in ik.semamod.imports.module2symbols.keys ():
+			rmfn = toCsym (rm.rsplit ('.', 1) [0]).lower ()
+			for sym in ik.semamod.imports.module2symbols [rm]:
+				ik.wout ('#define DER_PACK_' + toCsym (ik.unit) + '_' + toCsym (sym) + ' DER_PACK_' + toCsym (rmfn) + '_' + toCsym (sym) + '\n')
+				closer = '\n\n'
 		ik.wout (closer)
 
 	def generate_tail (ik):

--- a/asn1ate/asn2quickder.py
+++ b/asn1ate/asn2quickder.py
@@ -1,0 +1,267 @@
+#!/usr/bin/python
+#
+# asn2quickder -- Generate header files for C for use with Quick `n' Easy DER
+#
+# This program owes a lot to asn1ate, which was built to generate pyasn1
+# classes, but which was so well-written that it could be extended with a
+# code generator for Quick DER.
+#
+# Much of the code below is diagonally inspired on the pyasn1 backend, so
+# a very big thank you to Schneider Electric Buildings AB for helping to
+# make this program possible!
+#
+# From: Rick van Rein <rick@openfortress.nl>
+
+
+import sys
+import os.path
+
+from asn1ate import parser
+from asn1ate.sema import * 
+
+
+def toCsym (name):
+	"""Replace unsupported characters in ASN.1 symbol names"""
+	return str (name).replace (' ', '_').replace ('-', '_')
+
+
+class QuickDERgen ():
+	"""Generate the C header files for Quick DER, a.k.a. Quick and Easy DER.
+
+	   There are two things that are generated for each of the ASN.1 syntax
+	   declaration symbol of a unit:
+
+	   #define DER_PACK_unit_SyntaxDeclSym \
+			   DER_PACK_ENTER | ..., \
+			   ... \
+			   DER_PACK_LEAVE, \
+			   DER_PACK_END
+
+	   this is a walking path for the der_pack() and der_unpack() instructions.
+	   In addition, there will be a struct for each of the symbols:
+
+	   struct unit_SyntaxDeclSym_ovly {
+		   dercursor field1;
+		   dercursor field2;
+		   struct unit_EmbeddedSym_ovly field3;
+		   dercursor field4;
+	   };
+
+	   The unit prefix will be set to the filename of the module, usually
+	   something like rfc5280 when the parsed file is rfc5280.asn1 and the
+	   output is then written to rfc5280.h for easy inclusion by the C code.
+	"""
+
+	def __init__ (ik, semamod, outfn, refmods):
+		ik.semamod = semamod
+		ik.refmods = refmods
+		if outfn [-2:] == '.h':
+			raise Exception ('File cannot overwrite itself -- use another extension than .h for input files')
+		ik.unit = toCsym (outfn.rsplit ('.', 1) [0])
+		ik.outfile = open (ik.unit + '.h', 'w')
+		ik.wout = ik.outfile.write
+		# Setup function maps
+		ik.ovly_funmap = {
+			DefinedType: ik.ovlyDefinedType,
+			TypeAssignment: ik.ovlyTypeAssignment,
+			TaggedType: ik.ovlyTaggedType,
+			SimpleType: ik.ovlySimpleType,
+			SequenceType: ik.ovlyConstructedType,
+			SetType: ik.ovlyConstructedType,
+			ChoiceType: ik.ovlyConstructedType,
+			SequenceOfType: ik.ovlySimpleType,	# var sized
+			SetOfType: ik.ovlySimpleType,		# var sized
+		}
+		ik.pack_funmap = {
+			DefinedType: ik.packDefinedType,
+			TypeAssignment: ik.packTypeAssignment,
+			TaggedType: ik.packTaggedType,
+			SimpleType: ik.packSimpleType,
+			SequenceType: ik.packSequenceType,
+			SetType: ik.packSetType,
+			ChoiceType: ik.packChoiceType,
+			SequenceOfType: ik.packSequenceOfType,
+			SetOfType: ik.packSetOfType,
+		}
+
+	def newcomma (ik, comma, firstcomma=''):
+		ik.comma0 = firstcomma
+		ik.comma1 = comma
+
+	def comma (ik):
+		ik.wout (ik.comma0)
+		ik.comma0 = ik.comma1
+
+	def close (ik):
+		ik.outfile.close ()
+
+	def generate_head (ik):
+		ik.wout ('/*\n * asn2quickder output for ' + ik.semamod.name + ' -- automatically generated\n *\n * For information on Quick `n\' Easy DER, see https://github.com/vanrein/quick-der\n *\n */\n\n\n#include <quick-der/api.h>\n\n\n')
+		ik.wout ('/* This module ' + toCsym (ik.semamod.name) + ' depends on:\n')
+		for rm in ik.refmods:
+			ik.wout (' *   ' + toCsym (rm.name) + '\n')
+		if len (ik.refmods) == 0:
+			ik.wout (' *   (no other modules)\n')
+		ik.wout (' */\n\n')
+
+	def generate_tail (ik):
+		ik.wout ('\n\n/* asn2quickder output for ' + ik.semamod.name + ' ends here */\n')
+
+	def generate_ovly (ik):
+		ik.wout ('\n\n/* Overlay structures with ASN.1 derived nesting and labelling */\n\n')
+		for node in ik.semamod.assignments:
+			ik.generate_ovly_node (node)
+
+	def generate_pack (ik):
+		ik.wout ('\n\n/* Parser definitions in terms of ASN.1 derived bytecode instructions */\n\n')
+		for node in ik.semamod.assignments:
+			tnm = type (node)
+			if tnm in ik.pack_funmap:
+				ik.pack_funmap [tnm] (node)
+			else:
+				print 'No pack generator for ' + str (tnm)
+
+	def generate_ovly_node (ik, node):
+		tnm = type (node)
+		if tnm in ik.ovly_funmap:
+			ik.ovly_funmap [tnm] (node)
+		else:
+			print 'No overlay generator for ' + str (tnm)
+
+	def generate_pack_node (ik, node):
+		tnm = type (node)
+		if tnm in ik.pack_funmap:
+			ik.pack_funmap [tnm] (node)
+		else:
+			print 'No pack generator for ' + str (tnm)
+
+
+	def ovlyTypeAssignment (ik, node):
+		ik.wout ('typedef ')
+		ik.generate_ovly_node (node.type_decl)
+		ik.wout (' ' + ik.unit + '_' + toCsym (node.type_name) + '_ovly;\n\n')
+
+	def packTypeAssignment (ik, node):
+		ik.wout ('#define DER_PACK_' + ik.unit + '_' + toCsym (node.type_name))
+		ik.newcomma (', \\\\\n\t', ' \\\\\n\t')
+		ik.generate_pack_node (node.type_decl)
+		ik.wout ('\n\n')
+
+	def ovlyDefinedType (ik, node):
+		mod = node.module_name or ik.unit
+		ik.wout (toCsym (mod) + '_' + toCsym (node.type_name) + '_ovly')
+
+	def packDefinedType (ik, node):
+		mod = node.module_name or ik.unit
+		ik.comma ()
+		ik.wout ('DER_PACK_' + toCsym (mod) + '_' + toCsym (node.type_name))
+
+	def ovlySimpleType (ik, node):
+		ik.wout ('dercursor')
+
+	def packSimpleType (ik, node):
+		ik.comma ()
+		ik.wout ('DER_PACK_STORE | DER_TAG_' + node.type_name.replace (' ', '_').upper ())
+
+	def ovlyTaggedType (ik, node):
+		# tag = str (node) 
+		# tag = tag [:tag.find (']')] + ']'
+		# ik.wout ('/* ' + tag + ' */ ')
+		# if node.implicity == TagImplicity.IMPLICIT:
+		# 	tag = tag + ' IMPLICIT'
+		# elif node.implicity == TagImplicity.IMPLICIT:
+		# 	tag = tag + ' EXPLICIT'
+		ik.generate_ovly_node (node.type_decl)
+
+	def packTaggedType (ik, node):
+		#TODO# Need to push down node.implicity == TagImplicity.IMPLICIT
+		#TODO# Need to process tag class
+		ik.comma ()
+		ik.wout ('DER_PACK_ENTER | DER_' + (node.class_name or 'CONTEXT') + '_TAG(' + node.class_number + ')')
+		ik.generate_pack_node (node.type_decl)
+		ik.comma ()
+		ik.wout ('DER_PACK_LEAVE')
+
+	# Sequence, Set, Choice
+	def ovlyConstructedType (ik, node):
+		ik.wout ('struct {\n');
+		for comp in node.components:
+			ik.wout ('\t')
+			ik.generate_ovly_node (comp.type_decl)
+			ik.wout (' ' + toCsym (comp.identifier) + '; -- ' + str (comp.type_decl) + '\n')
+		ik.wout ('}')
+
+	def packSequenceType (ik, node):
+		ik.comma ()
+		ik.wout ('DER_PACK_ENTER | DER_TAG_SEQUENCE')
+		for comp in node.components:
+			if comp.optional:
+				ik.comma ()
+				ik.wout ('DER_PACK_OPTIONAL')
+			ik.generate_pack_node (comp.type_decl)
+		ik.comma ()
+		ik.wout ('DER_PACK_LEAVE')
+
+	def packSetType (ik, node):
+		ik.comma ()
+		ik.wout ('DER_PACK_ENTER | DER_TAG_SET')
+		for comp in node.components:
+			if comp.optional:
+				ik.comma ()
+				ik.wout ('DER_PACK_OPTIONAL')
+			ik.generate_pack_node (comp.type_decl)
+		ik.comma ()
+		ik.wout ('DER_PACK_LEAVE')
+
+	def packChoiceType (ik, node):
+		ik.comma ()
+		ik.wout ('DER_TAG_CHOICE_BEGIN')
+		for comp in node.components:
+			if comp.optional:
+				ik.comma ()
+				ik.wout ('DER_PACK_OPTIONAL')
+			ik.generate_pack_node (comp.type_decl)
+		ik.comma ()
+		ik.wout ('DER_TAG_CHOICE_BEGIN')
+
+	def packSequenceOfType (ik, node):
+		ik.comma ()
+		ik.wout ('DER_TAG_STORE | DER_TAG_SEQUENCE')
+
+	def packSetOfType (ik, node):
+		ik.comma ()
+		ik.wout ('DER_TAG_STORE | DER_TAG_SEQUENCE')
+
+
+"""The main program asn2quickder is called with one or more .asn1 files,
+   the first of which is mapped to a C header file and the rest is
+   loaded to fulfil dependencies.
+"""
+
+if len (sys.argv) < 2:
+	sys.stderr.write ('Usage: %s main[.asn1] dependency[.asn1]...\n'
+		% sys.argv [0])
+	sys.exit (1)
+
+mods = []
+for file in sys.argv [1:]:
+	print 'Parsing', file
+	asn1fh = open (file, 'r')
+	asn1txt = asn1fh.read ()
+	asn1fh.close ()
+	asn1tree = parser.parse_asn1 (asn1txt)
+	print 'Building semantic model for', file
+	asn1sem = build_semantic_model (asn1tree)
+	mods.insert (0, asn1sem [0])
+	print 'Realised semantic model for', file
+
+cogen = QuickDERgen (mods [-1], os.path.basename (sys.argv [1]), mods [1:])
+
+cogen.generate_head ()
+cogen.generate_ovly ()
+cogen.generate_pack ()
+cogen.generate_tail ()
+
+cogen.close ()
+
+

--- a/asn1ate/sema.py
+++ b/asn1ate/sema.py
@@ -722,15 +722,16 @@ class ValueListType(SemaNode):
 
 
 class Imports(SemaNode):
-    def __init__(self,elements):
+    def __init__(self, elements):
 	self.module2symbols = { }
-	for i in range (0,len(elements),2):
+	for i in range (0, len(elements), 2):
 		self.module2symbols [elements [i+1].elements[0]] = set (elements [i])
-	print 'Imported from', self.module2symbols.keys ()
 
-class Exports(Imports):
-    def __init__(self,elements):
-	Imports.__init__ (self, elements)
+class Exports(SemaNode):
+    def __init__(self, elements):
+	self.module2symbols = { }
+	for i in range (0, len(elements), 2):
+		self.module2symbols [elements [i+1].elements[0]] = set (elements [i])
 
 
 class BitStringType(SemaNode):

--- a/asn1ate/sema.py
+++ b/asn1ate/sema.py
@@ -270,6 +270,8 @@ class Module(SemaNode):
             self.tag_default = TagImplicity.EXPLICIT
 
         self.assignments = [_create_sema_node(token) for token in assignments.elements]
+	self.imports = _create_sema_node (imports)
+	self.exports = _create_sema_node (exports)
 
     def user_types(self):
         if not self._user_types:
@@ -719,6 +721,18 @@ class ValueListType(SemaNode):
     __repr__ = __str__
 
 
+class Imports(SemaNode):
+    def __init__(self,elements):
+	self.module2symbols = { }
+	for i in range (0,len(elements),2):
+		self.module2symbols [elements [i+1].elements[0]] = set (elements [i])
+	print 'Imported from', self.module2symbols.keys ()
+
+class Exports(Imports):
+    def __init__(self,elements):
+	Imports.__init__ (self, elements)
+
+
 class BitStringType(SemaNode):
     def __init__(self, elements):
         self.type_name = elements[0]
@@ -901,6 +915,10 @@ def _create_sema_node(token):
         return BinaryStringValue(token.elements)
     elif token.ty == 'HexStringValue':
         return HexStringValue(token.elements)
+    elif token.ty == 'Imports':
+	return Imports(token.elements)
+    elif token.ty == 'Exports':
+	return Exports(token.elements)
 
     raise Exception('Unknown token type: %s' % token.ty)
 


### PR DESCRIPTION
Hello kimgr,

Here is a patch that I propose to have added to asn1ate.  It uses your carefully designed compiler structure by adding a new backend "asn2quickder" -- and it adds a few extra's that you didn't need to the semantics module.

The target for this backend is the Quick DER parser/generator,
https://github.com/vanrein/quick-der
for which it generates C header files -- for example, for processing of ASN.1 portions from RFC's, as in
https://github.com/vanrein/quick-der/tree/master/rfc
The idea being that such include files are installed along with a Quick DER devel-package, making standard ASN.1 structure ready for immediate use.

I know that asn1ate targets Python, and indeed that is something I've considered that for the future too,
https://github.com/vanrein/quick-der/blob/master/PYTHON.MD

A last thought I've had is to derive clickable HTML files with ASN.1 structures,
https://github.com/vanrein/asn2quickder/issues/1

But first things first... would you be willing to add this extension to asn1ate?

I hope this pleases you as much as your compiler pleased me!

Thanks,
 -Rick