### PR TITLE
Add ASN1_SOURCE constant to output

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -37,7 +37,10 @@ ASN.1 definitions. The command to do this is::
 
   $ python .../asn1ate/pyasn1gen.py source.asn1
 
-It will print the ``pyasn1`` equivalent of ``source.asn1`` to stdout.
+It will print the ``pyasn1`` equivalent of ``source.asn1`` to stdout. Output
+will include a constant named ``ASN1_SOURCE`` containing the non-comment content
+of the source file; if the output is split into multiple Python modules, each
+module will have the corresponding ``ASN1_SOURCE``.
 
 But ``asn1ate`` is also designed to be usable as a library, to allow reuse of
 the ASN.1 parser for custom code generation.

--- a/README.txt
+++ b/README.txt
@@ -38,9 +38,10 @@ ASN.1 definitions. The command to do this is::
   $ python .../asn1ate/pyasn1gen.py source.asn1
 
 It will print the ``pyasn1`` equivalent of ``source.asn1`` to stdout. Output
-will include a constant named ``ASN1_SOURCE`` containing the non-comment content
-of the source file; if the output is split into multiple Python modules, each
-module will have the corresponding ``ASN1_SOURCE``.
+can also (when the appropriate flag is given) include a constant named
+``ASN1_SOURCE`` containing the non-comment content of the source file; if the
+output is split into multiple Python modules, each module will have the
+corresponding ``ASN1_SOURCE``.
 
 But ``asn1ate`` is also designed to be usable as a library, to allow reuse of
 the ASN.1 parser for custom code generation.

--- a/asn1ate/pyasn1gen.py
+++ b/asn1ate/pyasn1gen.py
@@ -639,8 +639,8 @@ def main():
     elif args.split:
         source_writer = pygen.Asn1SourceWriter()
     else:
-        source_writer = pygen.Asn1SourcesListWriter()
-        print(source_writer.sources_array_initializer(), file=output_file)
+        source_writer = pygen.Asn1SourcesCollectionWriter()
+        print(source_writer.collection_initializer(), file=output_file)
     for module in modules:
         try:
             if args.split:
@@ -648,14 +648,14 @@ def main():
             print(pygen.auto_generated_header(args.file, __version__),
                   file=output_file)
             if source_writer is not None:
-                print(source_writer.python_inclusion(str(module)),
+                print(source_writer.python_inclusion(module.name, str(module)),
                       file=output_file)
             generate_pyasn1(module, output_file, modules)
         finally:
             if output_file != sys.stdout:
                 output_file.close()
-    if hasattr(source_writer, 'join_of_array'):
-        print(source_writer.join_of_array())
+    if hasattr(source_writer, 'join_of_sources'):
+        print(source_writer.join_of_sources())
 
     return 0
 

--- a/asn1ate/pyasn1gen.py
+++ b/asn1ate/pyasn1gen.py
@@ -631,16 +631,25 @@ def main():
         print('WARNING: More than one module generated to the same stream.', file=sys.stderr)
 
     output_file = sys.stdout
+    if args.split:
+        source_writer = pygen.Asn1SourceWriter()
+    else:
+        source_writer = pygen.Asn1SourcesListWriter()
+        print(source_writer.sources_array_initializer(), file=output_file)
     for module in modules:
         try:
             if args.split:
                 output_file = open(_sanitize_module(module.name) + '.py', 'w')
             print(pygen.auto_generated_header(args.file, __version__),
                   file=output_file)
+            print(source_writer.python_inclusion(str(module)),
+                  file=output_file)
             generate_pyasn1(module, output_file, modules)
         finally:
             if output_file != sys.stdout:
                 output_file.close()
+    if not args.split:
+        print(source_writer.join_of_array())
 
     return 0
 

--- a/asn1ate/support/pygen.py
+++ b/asn1ate/support/pygen.py
@@ -105,3 +105,43 @@ class PythonFragment(PythonWriter):
 
     def __str__(self):
         return self.buf.getvalue()
+
+class Asn1SourceWriter(object):
+    const_name = "ASN1_SOURCE"
+    
+    def python_inclusion(self, asn1_str):
+        return "\n{} = {}\n".format(
+            self.const_name,
+            self.const_format(asn1_str)
+        ).format(asn1_str)
+    
+    @classmethod
+    def const_format(cls, asn1_str):
+        if '"""' in asn1_str:
+            return "{!r}"
+        else:
+            return 'r"""\n{}\n"""'
+
+class Asn1SourcesListWriter(Asn1SourceWriter):
+    array_const_name = Asn1SourceWriter.const_name + "_LIST"
+    
+    def __init__(self):
+        super(Asn1SourcesListWriter, self).__init__()
+        self.__array_initialized = False
+    
+    def sources_array_initializer(self, ):
+        self.__array_initialized = True
+        return "\n{} = []\n".format(self.array_const_name)
+    
+    def python_inclusion(self, asn1_str):
+        assert self.__array_initialized
+        return "\n{}.append({})\n".format(
+            self.array_const_name,
+            self.const_format(asn1_str)
+        ).format(asn1_str)
+    
+    def join_of_array(self):
+        return "\n{} = ''.join({})\n".format(
+            self.const_name,
+            self.array_const_name
+        )

--- a/asn1ate/support/pygen.py
+++ b/asn1ate/support/pygen.py
@@ -109,7 +109,7 @@ class PythonFragment(PythonWriter):
 class Asn1SourceWriter(object):
     const_name = "ASN1_SOURCE"
     
-    def python_inclusion(self, asn1_str):
+    def python_inclusion(self, module_name, asn1_str):
         return "\n{} = {}\n".format(
             self.const_name,
             self.const_format(asn1_str)
@@ -122,26 +122,27 @@ class Asn1SourceWriter(object):
         else:
             return 'r"""\n{}\n"""'
 
-class Asn1SourcesListWriter(Asn1SourceWriter):
-    array_const_name = Asn1SourceWriter.const_name + "_LIST"
+class Asn1SourcesCollectionWriter(Asn1SourceWriter):
+    collection_const_name = "ASN1_MODULE_SOURCES"
     
     def __init__(self):
-        super(Asn1SourcesListWriter, self).__init__()
-        self.__array_initialized = False
+        super(Asn1SourcesCollectionWriter, self).__init__()
+        self.__collection_initialized = False
     
-    def sources_array_initializer(self, ):
-        self.__array_initialized = True
-        return "\n{} = []\n".format(self.array_const_name)
+    def collection_initializer(self, ):
+        self.__collection_initialized = True
+        return "\n{} = dict()\n".format(self.collection_const_name)
     
-    def python_inclusion(self, asn1_str):
-        assert self.__array_initialized
-        return "\n{}.append({})\n".format(
-            self.array_const_name,
+    def python_inclusion(self, module_name, asn1_str):
+        assert self.__collection_initialized
+        return "\n{}[{!r}] = {}\n".format(
+            self.collection_const_name,
+            module_name,
             self.const_format(asn1_str)
         ).format(asn1_str)
     
-    def join_of_array(self):
-        return "\n{} = ''.join({})\n".format(
+    def join_of_sources(self):
+        return "\n{} = ''.join({}.values())\n".format(
             self.const_name,
-            self.array_const_name
+            self.collection_const_name
         )


### PR DESCRIPTION
This will allow consumers of the generated Python code to provide the ASN.1 definition(s) programmatically to any connected software or documentation system.