### PR TITLE
Add --include-asn1 switch to pyasn1gen.py

### DIFF
--- a/asn1ate/pyasn1gen.py
+++ b/asn1ate/pyasn1gen.py
@@ -126,6 +126,7 @@ class Pyasn1Backend(object):
         }
 
     def generate_code(self):
+        self.writer.write_line('# %s' % self.sema_module.name)
         self.writer.write_line('from pyasn1.type import univ, char, namedtype, namedval, tag, constraint, useful')
         for module in self.referenced_modules:
             if module is not self.sema_module:

--- a/asn1ate/support/pygen.py
+++ b/asn1ate/support/pygen.py
@@ -30,7 +30,7 @@ except ImportError:
     # Python 3
     from io import StringIO
 
-import os.path
+import os
 from datetime import datetime
 
 
@@ -105,3 +105,26 @@ class PythonFragment(PythonWriter):
 
     def __str__(self):
         return self.buf.getvalue()
+
+
+def format_longstring(content):
+    """ Wrap content in a Python longstring format.
+
+    E.g. format_longstring("Hello") will return:
+
+    \"\"\"
+    Hello
+    \"\"\"
+
+    Backslashes and inline triple-quotes are escaped.
+    """
+    escaped = content
+    escaped = escaped.replace('\\', '\\\\')
+    escaped = escaped.replace('"""', '\\"\\"\\"')
+
+    lines = [
+        '"""',
+        escaped,
+        '"""'
+    ]
+    return os.linesep.join(lines)

--- a/asn1ate/test.py
+++ b/asn1ate/test.py
@@ -38,6 +38,8 @@ def parse_args():
     ap.add_argument('file', help='ASN.1 file to test.')
     ap.add_argument('--outdir',
                     help='Write Python module files to directory instead of stdout')
+    ap.add_argument('--include-asn1', action='store_true',
+                    help='Pass --include-asn1 to code generator')
 
     # Actions
     group = ap.add_mutually_exclusive_group(required=True)
@@ -61,7 +63,8 @@ def generate_module_code(args):
         if split:
             os.chdir(args.outdir)
 
-        pyasn1gen.main(argparse.Namespace(file=infile, split=split))
+        pyasn1gen.main(argparse.Namespace(file=infile, split=split,
+                                          include_asn1=args.include_asn1))
     finally:
         os.chdir(prev_cwd)
 

--- a/testdata/string_escape.asn
+++ b/testdata/string_escape.asn
@@ -1,0 +1,8 @@
+-- Test handling of strings with escape chars
+Escaped DEFINITIONS ::=
+BEGIN
+  backslashString PrintableString ::= "This is a string with \ in it"
+  newlineString PrintableString ::= "String with \n in it"
+
+  -- TODO: Cover double- and triple-quote string escaping when that works
+END


### PR DESCRIPTION
This embeds the ASN.1 source into the generated Python code.

Since a Python file can contain multiple ASN.1 modules, the ASN1_SOURCES
constant is always a dict, and sources are keyed by ASN.1 module name.