### PR TITLE
Make the entrypoint asn1ate available again

### DIFF
--- a/asn1ate/pyasn1gen.py
+++ b/asn1ate/pyasn1gen.py
@@ -667,7 +667,7 @@ def main(args):
     return 0
 
 
-if __name__ == '__main__':
+def main_cli():
     arg_parser = argparse.ArgumentParser(
         description=('Generate Python classes from an ASN.1 definition file. '
                      'Output to stdout by default.'))
@@ -676,3 +676,7 @@ if __name__ == '__main__':
                             help='output multiple modules to separate files')
     args = arg_parser.parse_args()
     sys.exit(main(args))
+
+
+if __name__ == '__main__':
+    sys.exit(main_cli())

--- a/asn1ate/pyasn1gen.py
+++ b/asn1ate/pyasn1gen.py
@@ -675,7 +675,7 @@ def main_cli():
     arg_parser.add_argument('--split', action='store_true',
                             help='output multiple modules to separate files')
     args = arg_parser.parse_args()
-    sys.exit(main(args))
+    return main(args)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'asn1ate = asn1ate.pyasn1gen:main'
+            'asn1ate = asn1ate.pyasn1gen:main_cli'
         ]
     }
 )


### PR DESCRIPTION
In the current repository state, the asn1ate entrypoint exposed by setup.py fails with the error message:

```
$ asn1ate nrtrde.asn
Traceback (most recent call last):
  File "/note/.virtualenvs/sandbox/bin/asn1ate", line 11, in <module>
    load_entry_point('asn1ate', 'console_scripts', 'asn1ate')()
TypeError: main() missing 1 required positional argument: 'args'
```

Here is a little fix to do not break what was done for the unit tests and make the command running again :-).