### PR TITLE
keep the references sorted

### DIFF
--- a/asn1ate/sema.py
+++ b/asn1ate/sema.py
@@ -120,7 +120,7 @@ def dependency_sort(assignments):
     # Build the dependency graph.
     graph = {}
     for assignment in assignments:
-        references = assignment.references()
+        references = sorted(assignment.references())
         graph[assignment] = [assignments_by_name[r] for r in references
                              if r in assignments_by_name]
 


### PR DESCRIPTION
Using `set` for references garanty unicity but it scrambles them at each run.(producing different outputs).
Sorting them makes the output more stable. (avoid annoying diff after a regeneration)